### PR TITLE
Fix a bug to properly setup the AlexaSessions structure on an initial install.

### DIFF
--- a/Alexa.cfc
+++ b/Alexa.cfc
@@ -170,11 +170,15 @@
 		<cfargument name="intent" type="string" required="yes">
 		<cfargument name="slots" type="struct" required="yes">
 
-		<cfif this.isTesting and not structkeyExists(application.AlexaSessions,this.sessionId)>
+		<cfif not structkeyExists(Application,"AlexaSessions")>
+			<cfset Application.AlexaSessions = {}>
+		</cfif>
+		<cfif not structkeyExists(application.AlexaSessions,this.sessionId)>
 			<cfset Application.AlexaSessions[this.sessionId] = {
 				history = []
 			}>
 		</cfif>
+
 		<cfset arrayPrepend(application.AlexaSessions[this.sessionId].history, {
 			intent = arguments.intent,
 			slots = arguments.slots


### PR DESCRIPTION
The initial download was failing with AlexaSessions key not existing in the application scope. This code fixes the initial setup of the AlexaSessions structure on a brand new install.